### PR TITLE
fix(donwloader.js) : removing the __GHOST_URL__ when it exists in the…

### DIFF
--- a/src/downloader.js
+++ b/src/downloader.js
@@ -33,14 +33,15 @@ module.exports.doTheDownloads = async ( { jsonFile, baseUrl, basePath }, logger 
 		images = [ ...images, ...parseImages( post ) ];
 	} );
 	for ( let i = 0; i < images.length; i++ ) {
-		const image = images[ i ];
+		let image = images[ i ];
+		image = image.replace( "__GHOST_URL__", "" );
 		const parts = image.split( "/" );
 		const filename = parts.pop();
-		const localPath = `${ basePath }/${ parts.join( "/" ) }`;
+		const localPath = `${ basePath }${ parts.join( "/" ) }`;
 		const filePath = `${ localPath }/${ filename }`;
 		if ( !fs.existsSync( filePath ) ) {
 			fs.ensureDirSync( localPath );
-			const url = await downloadImage( `${ baseUrl }/${ image }`, filePath ); // eslint-disable-line no-await-in-loop
+			const url = await downloadImage( `${ baseUrl }${ image }`, filePath ); // eslint-disable-line no-await-in-loop
 			if ( url ) {
 				badUrls.push( url );
 			}


### PR DESCRIPTION
The ghost.json sometimes has __GHOT_URL__ prefix, like this: 
![image](https://user-images.githubusercontent.com/1921575/122954242-45af7000-d34d-11eb-88ab-b0651c8c5ed1.png)

Now the code removes it if it exists.

This PR also removes extra `/` 